### PR TITLE
Add HOL Standards SDK with RegistryBrokerClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ An open-source observability platform for GPT-3. Allows to track usage, costs, a
 
 </details>
 
+## [HOL Standards SDK](https://hol.org/docs/libraries/standards-sdk/overview/)
+The Hashgraph Online Standards SDK provides the RegistryBrokerClient - a typed, batteries-included wrapper around the Universal Agentic Registry. Enables AI agent discovery, registration, blockchain-based identity (ERC-8004, UAIDs), chat relay, and autonomous commerce via x402 protocol with Zod-backed validation.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Web](https://hol.org/)
+- [Registry](https://hol.org/registry)
+- [Documentation](https://hol.org/docs/libraries/standards-sdk/overview/)
+- [Registry Broker Client Docs](https://hol.org/docs/libraries/standards-sdk/registry-broker-client/)
+- [GitHub](https://github.com/hashgraph-online/standards-sdk)
+- [NPM](https://www.npmjs.com/package/@hashgraphonline/standards-sdk)
+
+</details>
+
 ## [Langchain](https://www.langchain.com/)
 LangChain is a framework designed to simplify the creation of applications using large language models.
 

--- a/README.md
+++ b/README.md
@@ -122,20 +122,16 @@ An open-source observability platform for GPT-3. Allows to track usage, costs, a
 
 </details>
 
-## [HOL Standards SDK](https://hol.org/docs/libraries/standards-sdk/overview/)
-The Hashgraph Online Standards SDK provides the RegistryBrokerClient - a typed, batteries-included wrapper around the Universal Agentic Registry. Enables AI agent discovery, registration, blockchain-based identity (ERC-8004, UAIDs), chat relay, and autonomous commerce via x402 protocol with Zod-backed validation.
+## [HOL Standards SDK](https://github.com/hashgraph-online/standards-sdk)
+TypeScript SDK for building AI agents on the Hedera network. Provides agent discovery and registration via the Registry Broker.
 
 <details>
 
-<!-- ### Description -->
-
 ### Links
-- [Web](https://hol.org/)
-- [Registry](https://hol.org/registry)
-- [Documentation](https://hol.org/docs/libraries/standards-sdk/overview/)
-- [Registry Broker Client Docs](https://hol.org/docs/libraries/standards-sdk/registry-broker-client/)
 - [GitHub](https://github.com/hashgraph-online/standards-sdk)
 - [NPM](https://www.npmjs.com/package/@hashgraphonline/standards-sdk)
+- [Documentation](https://hol.org/docs/libraries/standards-sdk/overview/)
+- [Website](https://hol.org/)
 
 </details>
 


### PR DESCRIPTION
Adding the Hashgraph Online Standards SDK.

TypeScript SDK for building AI agents on Hedera with agent discovery via the Registry Broker.

- GitHub: https://github.com/hashgraph-online/standards-sdk
- NPM: @hashgraphonline/standards-sdk
- Docs: https://hol.org/docs/libraries/standards-sdk/overview/