### PR TITLE
Add AgentGuard — runtime guardrails SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,15 @@ AgentOps create tools to make agents actually work, e.g., graphs, monitoring, an
 
 
 ## [AgentGuard](https://github.com/bmdhodl/agent47)
-Runtime guardrails SDK for AI agents — budget enforcement that kills agents mid-run, loop detection, and cost tracking. Zero dependencies, works with LangChain, LangGraph, CrewAI, and raw OpenAI/Anthropic calls.
+A lightweight Python SDK for AI agent observability with runtime guards — loop detection, budget enforcement, cost tracking. Zero dependencies, integrates with LangChain, LangGraph, and CrewAI.
 
 <details>
 
 ### Links
-- [Web](https://agentguard47.com)
 - [GitHub](https://github.com/bmdhodl/agent47)
 - [PyPI](https://pypi.org/project/agentguard47/)
 
 </details>
-
 
 ## [Chidori](https://github.com/ThousandBirdsInc/chidori)
 Chidori is a reactive runtime for building AI agents. It provides a framework for building AI agents that are reactive, observable, and robust. It supports building agents with Node.js, Python, and Rust.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ AgentOps create tools to make agents actually work, e.g., graphs, monitoring, an
 </details>
 
 
+## [AgentGuard](https://github.com/bmdhodl/agent47)
+Runtime guardrails SDK for AI agents — budget enforcement that kills agents mid-run, loop detection, and cost tracking. Zero dependencies, works with LangChain, LangGraph, CrewAI, and raw OpenAI/Anthropic calls.
+
+<details>
+
+### Links
+- [Web](https://agentguard47.com)
+- [GitHub](https://github.com/bmdhodl/agent47)
+- [PyPI](https://pypi.org/project/agentguard47/)
+
+</details>
+
+
 ## [Chidori](https://github.com/ThousandBirdsInc/chidori)
 Chidori is a reactive runtime for building AI agents. It provides a framework for building AI agents that are reactive, observable, and robust. It supports building agents with Node.js, Python, and Rust.
 It is currently in alpha, and is not yet ready for production use.


### PR DESCRIPTION
Adds [AgentGuard](https://github.com/bmdhodl/agent47) to the list (alphabetically, between AgentOps and Chidori).

**What it does:** Runtime guardrails for AI agents — budget enforcement (kills agents mid-run when spend exceeds limit), loop detection, and cost tracking.

- MIT licensed, zero dependencies, Python 3.9+
- Drop-in integrations for LangChain, LangGraph, CrewAI, and raw OpenAI/Anthropic
- [PyPI package](https://pypi.org/project/agentguard47/) — `pip install agentguard47`
- [Live site](https://agentguard47.com)