### PR TITLE
Add AgentField to AI agent SDKs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ E2b is an operating system for AI agents, that is, a set of tools, APIs, and clo
 </details>
 
 
+
+## [AgentField](https://agentfield.ai)
+AgentField is an open-source control plane for building and orchestrating autonomous AI agents, with SDKs for Python, TypeScript, and Go.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Web](https://agentfield.ai)
+- [GitHub](https://github.com/Agent-Field/agentfield)
+- [Documentation](https://agentfield.ai/docs)
+
+</details>
+
+
 ## [AgentOps](https://www.agentops.ai/)
 AgentOps create tools to make agents actually work, e.g., graphs, monitoring, and replay analytics.
 


### PR DESCRIPTION
## Summary

Adds [AgentField](https://github.com/Agent-Field/agentfield) to the SDKs list.

AgentField is an open-source control plane for building and orchestrating autonomous AI agents. It provides SDKs for Python, TypeScript, and Go with built-in support for:

- 100+ LLM providers (via LiteLLM)
- Tool calling and MCP (Model Context Protocol)
- Multi-agent orchestration
- Memory with vector search
- Web dashboard for agent management
- Prometheus metrics and monitoring

- **Website**: https://agentfield.ai
- **Docs**: https://agentfield.ai/docs
- **GitHub**: https://github.com/Agent-Field/agentfield

Placed in alphabetical order.

cc @AbirAbbas