### PR TITLE
Add tokio-prompt-orchestrator (Rust LLM orchestration SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+﻿
 <h1 align="center">
 	:gift: Awesome SDKs For AI Agents
 	<p align="center">
@@ -122,6 +122,21 @@ An open-source observability platform for GPT-3. Allows to track usage, costs, a
 
 </details>
 
+## [tokio-prompt-orchestrator](https://github.com/Mattbusel/tokio-prompt-orchestrator)
+
+### Category
+Infrastructure / Orchestration
+
+### Description
+Production Rust SDK for LLM pipeline orchestration. Multi-stage async pipeline (RAG -> Assemble -> Infer -> Post-process -> Stream) with:
+- Circuit breaker, deduplication, retry, rate limiting, backpressure
+- 67% inference cost collapse via dedup in production
+- Self-improving autonomous control loop (PID + anomaly detection)
+- MCP server for Claude Desktop/Code integration
+- Ran 24 simultaneous Claude Code agents on a single GPU
+
+### Links
+- [GitHub](https://github.com/Mattbusel/tokio-prompt-orchestrator)
 ## [Langchain](https://www.langchain.com/)
 LangChain is a framework designed to simplify the creation of applications using large language models.
 


### PR DESCRIPTION
## Summary

Adds [tokio-prompt-orchestrator](https://github.com/Mattbusel/tokio-prompt-orchestrator) — a production-grade Rust SDK for multi-agent LLM pipeline orchestration.

**Capabilities:**
- Multi-stage pipeline with circuit breakers, deduplication, adaptive rate limiting, backpressure
- Self-tuning controller: automatically adjusts concurrency and model routing
- Distributed coordination via NATS/Redis
- Evolution engine: online A/B experiments with automatic promotion
- MCP (Model Context Protocol) server built-in
- Zero panics, typed errors, aerospace-grade test coverage (1.5:1 ratio)
- Benchmarked at 45K req/s on 16-core hardware

**Language:** Rust / Tokio async runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)