### PR TITLE
Add LemonCake — Pay Tokens + auto-journaling for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,15 +170,15 @@ A unified platform for debugging, testing, evaluating, and monitoring LLM applic
 
 </details>
 
-## [LemonCake](https://lemoncake.xyz?utm_source=awesome-ai-sdks&utm_medium=github)
-Pay Tokens for AI agents — JWT-signed upstream API payment proxy with hard USDC spending caps, expiry, domain scope, and a sub-second kill-switch. Every charge is auto-journaled to freee / Money Forward (Japanese accounting, including source-withholding splits and adaptive-invoice-number checks) or QuickBooks. SDKs for Dify, Coze, MCP, and Eliza.
+## [LemonCake](https://lemoncake.xyz)
+Pay Tokens for AI agents — JWT-signed upstream API payment proxy with hard USDC spending caps, expiry, domain scope, and a sub-second kill-switch. Every charge is auto-journaled to freee / Money Forward (Japanese accounting, including source-withholding splits and adaptive-invoice-number checks) or QuickBooks. MIT-licensed SDKs for Dify, MCP, and Eliza.
 
 <details>
 
 <!-- ### Description -->
 
 ### Links
-- [Web](https://lemoncake.xyz?utm_source=awesome-ai-sdks&utm_medium=github)
+- [Web](https://lemoncake.xyz)
 - [GitHub](https://github.com/evidai/lemon-cake)
 - [npm: lemon-cake-mcp](https://www.npmjs.com/package/lemon-cake-mcp)
 - [npm: eliza-plugin-lemoncake](https://www.npmjs.com/package/eliza-plugin-lemoncake)

--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ A unified platform for debugging, testing, evaluating, and monitoring LLM applic
 
 </details>
 
+## [LemonCake](https://lemoncake.xyz)
+Pay Tokens for AI agents — JWT-signed upstream API payment proxy with hard USDC spending caps, expiry, domain scope, and a sub-second kill-switch. Every charge is auto-journaled to freee / Money Forward (Japanese accounting, including source-withholding splits and adaptive-invoice-number checks) or QuickBooks. SDKs for Dify, Coze, MCP, and Eliza.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Web](https://lemoncake.xyz)
+- [GitHub](https://github.com/evidai/lemon-cake)
+- [npm: lemon-cake-mcp](https://www.npmjs.com/package/lemon-cake-mcp)
+- [npm: eliza-plugin-lemoncake](https://www.npmjs.com/package/eliza-plugin-lemoncake)
+
+</details>
+
+
 ## [SID](https://www.sid.ai/)
 
 SID is a YC S23 company that makes data infrastructure for AI easy by letting AI devs connect to all of their customer's data with a single button and API.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ A unified platform for debugging, testing, evaluating, and monitoring LLM applic
 
 </details>
 
-## [LemonCake](https://lemoncake.xyz)
+## [LemonCake](https://lemoncake.xyz?utm_source=awesome-ai-sdks&utm_medium=github)
 Pay Tokens for AI agents — JWT-signed upstream API payment proxy with hard USDC spending caps, expiry, domain scope, and a sub-second kill-switch. Every charge is auto-journaled to freee / Money Forward (Japanese accounting, including source-withholding splits and adaptive-invoice-number checks) or QuickBooks. SDKs for Dify, Coze, MCP, and Eliza.
 
 <details>
@@ -178,7 +178,7 @@ Pay Tokens for AI agents — JWT-signed upstream API payment proxy with hard USD
 <!-- ### Description -->
 
 ### Links
-- [Web](https://lemoncake.xyz)
+- [Web](https://lemoncake.xyz?utm_source=awesome-ai-sdks&utm_medium=github)
 - [GitHub](https://github.com/evidai/lemon-cake)
 - [npm: lemon-cake-mcp](https://www.npmjs.com/package/lemon-cake-mcp)
 - [npm: eliza-plugin-lemoncake](https://www.npmjs.com/package/eliza-plugin-lemoncake)


### PR DESCRIPTION
Adds [LemonCake](https://lemoncake.xyz) — a JWT-signed upstream API payment proxy for AI agents.

**What it is**

A proxy that issues **Pay Tokens** (HMAC-SHA256-signed JWTs) to AI agents. Every token carries a hard USDC spending cap, an expiry, and a domain scope that is enforced at signature-verification time. A sub-second kill-switch revokes every live token at once.

Each settled call is auto-journaled to **freee / Money Forward** (Japanese accounting, including source-withholding percentage splits and adaptive-invoice-number checks against the National Tax Agency API) or **QuickBooks**. Settles in USDC on Base.

**SDKs / integrations shipped**

- Dify plugin
- Coze plugin
- MCP server ([npm: lemon-cake-mcp](https://www.npmjs.com/package/lemon-cake-mcp))
- Eliza plugin ([npm: eliza-plugin-lemoncake](https://www.npmjs.com/package/eliza-plugin-lemoncake))

Inserted in alphabetical position between LangSmith and SID. Thanks for maintaining the list!