### PR TITLE
Add anchor-x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ AgentOps create tools to make agents actually work, e.g., graphs, monitoring, an
 
 
 ## [anchor-x402](https://anchor-x402.com/)
-Nine x402-paid commodity services for AI agents on Base + Solana mainnet — dual-chain hash anchoring, OFAC sanctions screening, signed decision attestation, tx decode, ENS/SNS resolution, USD price, calldata decode, datetime parser, and bundled wallet intelligence. Pay per call in USDC, no API keys.
+Sixteen x402-paid services for AI agents on Base + Solana mainnet — nine commodity primitives (dual-chain hash anchoring, OFAC sanctions screening, signed decision attestation, tx decode, ENS/SNS resolution, USD price, calldata decode, datetime parser, bundled wallet intel), one async due-diligence investigator (`/v1/investigate`, $7.77), one verifiable signed RNG (`/v1/roll`), and five universal LLM endpoints (roast, oracle with anchored verdict, tldr, aura, grade). Pay per call in USDC, no API keys.
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ AgentOps create tools to make agents actually work, e.g., graphs, monitoring, an
 </details>
 
 
+## [anchor-x402](https://anchor-x402.com/)
+Nine x402-paid commodity services for AI agents on Base + Solana mainnet — dual-chain hash anchoring, OFAC sanctions screening, signed decision attestation, tx decode, ENS/SNS resolution, USD price, calldata decode, datetime parser, and bundled wallet intelligence. Pay per call in USDC, no API keys.
+
+<details>
+
+<!-- ### Description -->
+
+
+### Links
+- [Web](https://anchor-x402.com/)
+- [GitHub](https://github.com/hypeprinter007-stack/anchor-x402)
+- [API Docs](https://api.anchor-x402.com/docs)
+- [MCP Server (npm)](https://www.npmjs.com/package/anchor-x402-mcp)
+
+</details>
+
+
 ## [Chidori](https://github.com/ThousandBirdsInc/chidori)
 Chidori is a reactive runtime for building AI agents. It provides a framework for building AI agents that are reactive, observable, and robust. It supports building agents with Node.js, Python, and Rust.
 It is currently in alpha, and is not yet ready for production use.


### PR DESCRIPTION
## Summary

Adds **anchor-x402** — a 9-service x402-paid API for AI agents — to the list, alphabetically between AgentOps and Chidori. Matches the existing entry format precisely (`## [Name](url)`, one-line description, `<details>` block with Links).

- Nine services on Base + Solana mainnet: dual-chain hash anchoring, OFAC sanctions screening, signed decision attestation, tx decode, ENS/SNS resolution, USD price, calldata decode, datetime parser, bundled wallet intelligence
- Pay per call in USDC ($0.001–$0.010), no API keys, no accounts
- Indexed in CDP Bazaar, agentic.market, MCP Registry, Glama (License A / Quality A)
- MIT-licensed source: https://github.com/hypeprinter007-stack/anchor-x402
- Companion MCP server: `anchor-x402-mcp` on npm