### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ AgentOps create tools to make agents actually work, e.g., graphs, monitoring, an
 </details>
 
 
+## [APort](https://aport.io/)
+APort provides pre-action authorization guardrails for AI agents, enforcing policies before tool calls and producing auditable decisions.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Web](https://aport.io/)
+- [GitHub](https://github.com/aporthq/aport-agent-guardrails)
+
+
+</details>
+
+
 ## [Chidori](https://github.com/ThousandBirdsInc/chidori)
 Chidori is a reactive runtime for building AI agents. It provides a framework for building AI agents that are reactive, observable, and robust. It supports building agents with Node.js, Python, and Rust.
 It is currently in alpha, and is not yet ready for production use.
@@ -219,5 +234,4 @@ An open source library for building AI-powered user interfaces.
 
 
 </details>
-
 


### PR DESCRIPTION
## Summary
- Add APort as an AI-agent guardrails tool.
- Include the APort website and guardrails GitHub repository in the existing Links format.

## Validation
- git diff --check
- Verified https://aport.io returns HTTP 200
- Verified https://github.com/aporthq/aport-agent-guardrails returns HTTP 200