### PR TITLE
Add EFC (Everything Fact-Checked) — fact-checking tool for AI agent research output

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,19 @@ An open source library for building AI-powered user interfaces.
 
 </details>
 
+## [Everything Fact-Checked](https://github.com/Nlai741533/EFC-Plugin)
+
+A fact-checking toolkit for AI-generated research reports. CLI, Claude Code plugin, and GitHub Action that catches hallucinated numbers, fabricated data, and exaggerated claims before they reach your reader.
+
+<details>
+
+### Links
+- [GitHub (Plugin)](https://github.com/Nlai741533/EFC-Plugin)
+- [GitHub (Standalone Skill)](https://github.com/Nlai741533/EFC-standalone)
+- [PyPI](https://pypi.org/project/everything-fact-checked/)
+
+</details>
+
 
 ## [EFC (Everything Fact-Checked)](https://github.com/Nlai741533/EFC-Plugin)
 EFC is a fact-checking tool for AI-generated research reports. It catches 5 systematic failure modes (unit errors, fabricated interpolation, source conflation, stale data, attribution laundering) through an agent-agnostic SKILL.md, CLI (`efc`), and GitHub Action. Includes source-content verification that fetches cited URLs and checks whether claimed figures actually appear in the source text.

--- a/README.md
+++ b/README.md
@@ -221,3 +221,15 @@ An open source library for building AI-powered user interfaces.
 </details>
 
 
+## [EFC (Everything Fact-Checked)](https://github.com/Nlai741533/EFC-Plugin)
+EFC is a fact-checking tool for AI-generated research reports. It catches 5 systematic failure modes (unit errors, fabricated interpolation, source conflation, stale data, attribution laundering) through an agent-agnostic SKILL.md, CLI (`efc`), and GitHub Action. Includes source-content verification that fetches cited URLs and checks whether claimed figures actually appear in the source text.
+
+<details>
+
+### Links
+- [GitHub](https://github.com/Nlai741533/EFC-Plugin)
+- [Standalone Skill (one file, any agent)](https://github.com/Nlai741533/EFC-standalone)
+
+</details>
+
+


### PR DESCRIPTION
## EFC (Everything Fact-Checked)

A fact-checking tool designed specifically for AI agent output — research reports, market analyses, and data-heavy documents.

**What it does:** AI agents producing research at scale fail in 5 systematic ways. EFC catches them:

1. **Unit/scale errors** — $4.2B → $4,200B (dropped conversions)
2. **Fabricated interpolation** — charts with data points the agent invented
3. **Source conflation** — GMV cited as revenue, different metrics merged
4. **Stale data as current** — outdated figures presented as latest
5. **Attribution laundering** — blogs cited as official filings

**Agent integration formats:**
- Agent-agnostic SKILL.md (one file, works with any LLM agent)
- CLI (`efc`) for local and CI use
- GitHub Action for automated PR fact-checking
- Source-content verification: fetches cited URLs and checks if claims appear

**Tech:** Stdlib-only Python, MIT license, 72 tests, zero dependencies.

- Full repo: https://github.com/Nlai741533/EFC-Plugin
- Standalone skill: https://github.com/Nlai741533/EFC-standalone