### PR TITLE
Add OpenClaw Monitor - free open-source monitoring dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ AgentOps create tools to make agents actually work, e.g., graphs, monitoring, an
 </details>
 
 
+
+## [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor)
+Free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, multi-model support.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Web](https://github.com/flik2002/openclaw-monitor)
+- [Screenshot](https://raw.githubusercontent.com/flik2002/openclaw-monitor/main/Openclaw%20Monitor.jpg)
+
+
+</details>
+
+
 ## [Chidori](https://github.com/ThousandBirdsInc/chidori)
 Chidori is a reactive runtime for building AI agents. It provides a framework for building AI agents that are reactive, observable, and robust. It supports building agents with Node.js, Python, and Rust.
 It is currently in alpha, and is not yet ready for production use.


### PR DESCRIPTION
## OpenClaw Monitor

Free open-source monitoring dashboard for [OpenClaw AI agents](https://github.com/flik2002/openclaw-monitor).

### Features
- Token usage tracking
- Session tracking
- 7-day trend charts
- Multi-model support

### Links
- Repo: https://github.com/flik2002/openclaw-monitor
- Screenshot: https://raw.githubusercontent.com/flik2002/openclaw-monitor/main/Openclaw%20Monitor.jpg

---
*Submitted via GitHub API*