### PR TITLE
Add FiatDock — non-custodial MCP marketplace for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ It is currently in alpha, and is not yet ready for production use.
 
 ## [FiatDock](https://fiatdock.com)
 
-FiatDock is a non-custodial USDC ↔ bank on/off-ramp for AI agents. It gives any MCP-capable agent four tools — free quotes with all fees itemised, off-ramp and on-ramp sessions at $0.05 USDC per call paid automatically via the x402 protocol, and order tracking. Conversion, KYC and custody are handled by Transak, a licensed provider; the binding own-account rule applies (the sending wallet and the receiving bank account belong to the agent's owner). Available via `npx fiatdock-mcp`, a remote Streamable HTTP endpoint at `https://fiatdock.com/mcp`, and a plain REST API.
+FiatDock is a non-custodial marketplace where AI agents discover and pay for MCP services per call in USDC via the x402 protocol on Base. Agents use three MCP tools — `search_services`, `get_service` and `call_service` — to find a service and call it (the `fiatdock-mcp` package auto-pays the 402). Each paid call settles directly from the buyer's wallet to the seller's wallet; FiatDock takes a 1% fee as an on-chain split (0% for a seller's first 30 days) and never holds funds. Sellers list free and keep 99%. FiatDock also offers a non-custodial USDC↔bank on/off-ramp. Available via `npx fiatdock-mcp`, a remote Streamable HTTP endpoint at `https://fiatdock.com/mcp`, and a plain REST API.
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ It is currently in alpha, and is not yet ready for production use.
 
 </details>
 
+## [FiatDock](https://fiatdock.com)
+
+FiatDock is a non-custodial USDC ↔ bank on/off-ramp for AI agents. It gives any MCP-capable agent four tools — free quotes with all fees itemised, off-ramp and on-ramp sessions at $0.05 USDC per call paid automatically via the x402 protocol, and order tracking. Conversion, KYC and custody are handled by Transak, a licensed provider; the binding own-account rule applies (the sending wallet and the receiving bank account belong to the agent's owner). Available via `npx fiatdock-mcp`, a remote Streamable HTTP endpoint at `https://fiatdock.com/mcp`, and a plain REST API.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Web](https://fiatdock.com)
+- [GitHub](https://github.com/fiatdock/fiatdock)
+- [npm](https://www.npmjs.com/package/fiatdock-mcp)
+
+</details>
+
 ## [Fixie]()
 
 Fixie is a platform for conversational AI that enables to build agents in any language. They have their own [agent protocol](https://docs.fixie.ai/agent-protocol/).


### PR DESCRIPTION
This updates the FiatDock entry to lead with what it is today: a **non-custodial marketplace where AI agents discover and pay for MCP services per call** via x402 on Base.

- 3 MCP tools — `search_services`, `get_service`, `call_service`.
- Each paid call settles **directly buyer-wallet → seller-wallet**; the 1% platform fee is an **on-chain split** (0% for a seller's first 30 days), so FiatDock never holds funds.
- Sellers list **free** and keep 99%; Verified sellers pass a KYC + security scan.
- Also exposes a non-custodial **USDC↔bank on/off-ramp**.

Site: https://fiatdock.com · what it is: https://fiatdock.com/mcp-marketplace.html · `npx fiatdock-mcp` · remote MCP `https://fiatdock.com/mcp`
