### PR TITLE
Add AI Native Dev to agent SDK tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ E2b is an operating system for AI agents, that is, a set of tools, APIs, and clo
 
 </details>
 
+-
+
+-
+
 
 ## [AI Native Dev / vibe-skills](https://skill.ferryman.app/)
 Open Agent Skills bundle for repo-native AI coding workflows.
@@ -236,3 +240,4 @@ An open source library for building AI-powered user interfaces.
 
 </details>
 
+-

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ E2b is an operating system for AI agents, that is, a set of tools, APIs, and clo
 </details>
 
 
+## [AI Native Dev / vibe-skills](https://skill.ferryman.app/)
+Open Agent Skills bundle for repo-native AI coding workflows.
+
+<details>
+
+<!-- ### Description -->
+
+AI Native Dev publishes portable Agent Skills for project instructions, specs, reviews, plans, prototypes, validation evidence, handoffs, and commit preparation.
+
+### Links
+- [Web](https://skill.ferryman.app/)
+- [Registry](https://skill.ferryman.app/.well-known/agent-skills/index.json)
+
+</details>
+
+
 ## [AgentOps](https://www.agentops.ai/)
 AgentOps create tools to make agents actually work, e.g., graphs, monitoring, and replay analytics.
 
@@ -219,5 +235,4 @@ An open source library for building AI-powered user interfaces.
 
 
 </details>
-
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,6 @@ E2b is an operating system for AI agents, that is, a set of tools, APIs, and clo
 
 </details>
 
--
-
--
-
-
 ## [AI Native Dev / vibe-skills](https://skill.ferryman.app/)
 Open Agent Skills bundle for repo-native AI coding workflows.
 


### PR DESCRIPTION
Adds AI Native Dev / vibe-skills as an open Agent Skills bundle for repo-native AI coding workflows. It fits this list as a tool/workflow layer for AI coding agents, covering project instructions, specs, reviews, plans, validation evidence, handoffs, and commit preparation.