### PR TITLE
Add Kakunin (identity & compliance SDK for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ An open-source observability platform for GPT-3. Allows to track usage, costs, a
 
 </details>
 
+## [Kakunin](https://www.kakunin.ai/)
+Kakunin is compliance and identity infrastructure for AI agents — it issues X.509 certificates, enforces per-agent action scope before execution, scores behaviour, and auto-revokes credentials on risk, with a tamper-evident audit trail for MiCA / EU AI Act. TypeScript and Python SDKs.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Web](https://www.kakunin.ai/)
+- [GitHub](https://github.com/nqzai/kakunin-core)
+- [Docs](https://www.kakunin.ai/docs)
+
+</details>
+
 ## [Langchain](https://www.langchain.com/)
 LangChain is a framework designed to simplify the creation of applications using large language models.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Kakunin is compliance and identity infrastructure for AI agents — it issues X.
 
 ### Links
 - [Web](https://www.kakunin.ai/)
-- [GitHub](https://github.com/nqzai/kakunin-core)
+- [GitHub](https://github.com/kakunin-ai/kakunin-core)
 - [Docs](https://www.kakunin.ai/docs)
 
 </details>


### PR DESCRIPTION
Adds **Kakunin** in alphabetical order (between Helicone and Langchain).

Kakunin is open-source (AGPL-3.0 platform, Apache-2.0 SDKs) identity & compliance infrastructure for AI agents: it issues X.509 certificates, enforces per-agent action scope before execution, scores behaviour, and auto-revokes credentials on risk, with a tamper-evident audit trail for MiCA / EU AI Act. TypeScript (`@kakunin/sdk`) and Python (`kakunin`) SDKs.

- Web: https://www.kakunin.ai/
- GitHub: https://github.com/nqzai/kakunin-core
- Docs: https://www.kakunin.ai/docs

Disclosure: I maintain Kakunin.