### PR TITLE
docs(readme): add UTM tracking to e2b.dev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Feel free to reach out to us at [hello@e2b.dev](mailto:hello@e2b.dev).
 Check out also our database of [AI agents](https://github.com/e2b-dev/awesome-ai-agents).
 
 
-## [E2B](https://www.e2b.dev/)
+## [E2B](https://e2b.dev/?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=awesome-ai-sdks)
 E2b is an operating system for AI agents, that is, a set of tools, APIs, and cloud environments for  agents.
 
 
@@ -45,7 +45,7 @@ E2b is an operating system for AI agents, that is, a set of tools, APIs, and clo
 
 
 ### Links
-- [Web](https://www.e2b.dev/)
+- [Web](https://e2b.dev/?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=awesome-ai-sdks)
 - [GitHub](https://github.com/e2b-dev)
     - [e2b Dashboard](https://github.com/e2b-dev/e2b)
     - [The Agent Protocol](https://github.com/e2b-dev/agent-protocol)


### PR DESCRIPTION
Adds UTM parameters to the e2b.dev link(s) in the README so GitHub-referral traffic is attributed per repo.

`utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=<repo>`

Applies to apex e2b.dev links (root and subpaths). Subdomains and already-tagged links are untouched, and URL anchors are preserved.