### PR TITLE
Add Lians agent memory SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ A unified platform for debugging, testing, evaluating, and monitoring LLM applic
 
 </details>
 
+## [Lians](https://github.com/Lians-ai/Lians)
+Lians is an open-source, local-first memory layer for AI agents. It gives agents durable memory across chats, sessions, tools, and models through MCP and Python or TypeScript SDKs.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Documentation](https://www.lians.ai/docs)
+- [GitHub](https://github.com/Lians-ai/Lians)
+- [Five-minute MCP setup](https://lians-memory.hashnode.dev/give-any-ai-agent-persistent-memory-locally)
+
+</details>
+
 ## [SID](https://www.sid.ai/)
 
 SID is a YC S23 company that makes data infrastructure for AI easy by letting AI devs connect to all of their customer's data with a single button and API.


### PR DESCRIPTION
## What changed

Adds Lians to the SDK and tooling list with links to its Apache-2.0 repository, documentation, and a five-minute MCP setup.

## Why it fits

Lians is a developer-facing memory layer for AI agents. It exposes local-first durable memory through MCP and Python or TypeScript SDKs, so it fits this repository's scope of SDKs, frameworks, libraries, and tools for building agents.

## Verification

- Confirmed the repository is public: https://github.com/Lians-ai/Lians
- Confirmed the documentation and setup links are public.
- Kept the entry factual and disclosed through the project repository link.
